### PR TITLE
Accept the "200 Connection Established" response

### DIFF
--- a/ProxiedTcpClient/ProxiedTcpClient.cs
+++ b/ProxiedTcpClient/ProxiedTcpClient.cs
@@ -59,7 +59,7 @@ namespace Filemail.ProxiedTcpClient
 
             var response = ASCIIEncoding.ASCII.GetString(receiveBuffer, 0, received);
 
-            if (!response.Contains("200 OK", StringComparison.OrdinalIgnoreCase) && !response.Contains("200 Connection Established", StringComparison.OrdinalIgnoreCase))
+            if (response.IndexOf("200 OK", StringComparison.OrdinalIgnoreCase) == -1 && response.IndexOf("200 Connection Established", StringComparison.OrdinalIgnoreCase) == -1)
             {
                 throw new Exception($"Error connecting to proxy server {destination.Host}:{destination.Port}. Response: {response}");
             }

--- a/ProxiedTcpClient/ProxiedTcpClient.cs
+++ b/ProxiedTcpClient/ProxiedTcpClient.cs
@@ -59,7 +59,7 @@ namespace Filemail.ProxiedTcpClient
 
             var response = ASCIIEncoding.ASCII.GetString(receiveBuffer, 0, received);
 
-            if (!response.Contains("200 OK"))
+            if (!response.Contains("200 OK", StringComparison.OrdinalIgnoreCase) && !response.Contains("200 Connection Established", StringComparison.OrdinalIgnoreCase))
             {
                 throw new Exception($"Error connecting to proxy server {destination.Host}:{destination.Port}. Response: {response}");
             }


### PR DESCRIPTION
According to the standard (see https://tools.ietf.org/html/draft-luotonen-web-proxy-tunneling-01#section-3.2), the valid (or even preferred) proxy response is `200 Connection established`
>  If everything is in order, the proxy will make a  connection to the destination server, and, if successful, send a "200 Connection established" response to the client.

I tested it with my local proxy server ([Telerik Fiddler](https://www.telerik.com/fiddler)) which returns "200 Connection Established" for new tunnels. 

So, this change adds the "200 Connection Established" as a valid response (and also uses case-insensitive comparison, because the standard says "Connection established" and at least Telerik Fiddler proxy uses "Connection Established"...)